### PR TITLE
Update file-tree

### DIFF
--- a/scripts/file-tree
+++ b/scripts/file-tree
@@ -16,7 +16,8 @@ SRCROOT="${BASE}/xochitl"
 TGTROOT="${BASE}/file-tree"
 URL="http://10.11.99.1/download"
 # rclone support if available (http://rclone.org)
-RCLONE="rclone"
+RCLONE="rclone" # change to the rclone binary (add the path if rclone is outside of $PATH)
+RCLONE_CONFIG="/home/root/.rclone.conf" # change to the config file created by 'rclone config'
 UPLOAD="cloud:reMarkable" # sync to a reMarkable folder on the remote rclone storage "cloud"
 
 # Flags
@@ -155,7 +156,7 @@ then
     if [[ -n "${RCLONE}" && -x "${RCLONE}" && -n "${UPLOAD}" ]]
     then
         [[ -z "${QUIET}" ]] && echo "Syncing ${TGTROOT}/ to ${UPLOAD}/ ..."
-        "${RCLONE}" sync ${VERBOSE:+--verbose} --delete-excluded "${TGTROOT}/" "${UPLOAD}/"
+        "${RCLONE}" sync ${VERBOSE:+--verbose} --config ${RCLONE_CONFIG} --delete-excluded "${TGTROOT}/" "${UPLOAD}/"
     else
         echo "ERROR: Unable to sync as rclone is not available or correctly configured" >&2
     fi


### PR DESCRIPTION
file-tree: add config path variable for rclone
Depending on the situation, rclone can't find its config. Thus, users should be able to point to the config